### PR TITLE
[TinyBERT] Custom step to produce metadata that the shell integration can pick up.

### DIFF
--- a/src/finnbrainsmith/util/bert.py
+++ b/src/finnbrainsmith/util/bert.py
@@ -9,6 +9,8 @@
 
 import onnx
 import argparse
+import os
+import json
 from onnxsim import simplify
 import qonnx.custom_op.registry as registry
 from qonnx.util.cleanup import cleanup
@@ -26,6 +28,7 @@ from finn.transformation.fpgadataflow.specialize_layers import SpecializeLayers
 from finn.transformation.qonnx.convert_qonnx_to_finn import ConvertQONNXtoFINN
 from qonnx.transformation.fold_constants import FoldConstants
 from qonnx.transformation.infer_datatypes import InferDataTypes
+from finn.builder.build_dataflow_config import DataflowOutputType
 import finn.transformation.streamline as absorb
 import finn.transformation.streamline.reorder as reorder
 from finn.transformation.streamline.round_thresholds import RoundAndClipThresholds
@@ -179,6 +182,69 @@ def custom_step_infer_hardware(model, cfg):
     model = model.transform(to_hw.InferQuantizedMatrixVectorActivation())
     return model
 
+class ExtractShellIntegrationMetadata(Transformation):
+    """ Walks the ONNX graph and extracts all relevant metadata for shell integration
+    handover. """
+    def __init__(self, metadata_file:str):
+        super().__init__()
+        self.metadata_file:str = metadata_file
+        self.md = {}
+
+    def apply(self, model):
+        graph = model.graph
+
+        # Extract instream widths
+        instreams = {}
+        for input_tensor in graph.input:
+            consumer = model.find_consumer(input_tensor.name)
+            inst = registry.getCustomOp(consumer)
+            instream = {}
+            instream['width'] = inst.get_instream_width() 
+            instreams[input_tensor.name] = instream
+            instream['shape'] = inst.get_normal_input_shape() 
+        self.md['insteams'] = instreams
+
+        # Extract outstream widths
+        outstreams = {}
+        for output_tensor in graph.output:
+            producer = model.find_producer(output_tensor.name)
+            inst = registry.getCustomOp(producer)
+            outstream = {}
+            outstream['width'] = inst.get_outstream_width() 
+            outstreams[output_tensor.name] = outstream
+            outstream['shape'] = inst.get_normal_output_shape()
+        self.md['outsteams'] = outstreams
+    
+        static_matmuls = {}
+        for node in graph.node:
+            if (node.op_type == "MVAU_rtl"):
+                inst = registry.getCustomOp(node)
+                mm = {}
+                mm['MH'] = inst.get_nodeattr("MH")
+                mm['MW'] = inst.get_nodeattr("MW")
+                mm['SIMD'] = inst.get_nodeattr("SIMD")
+                mm['PE'] = inst.get_nodeattr("PE")
+                static_matmuls[node.name] = mm
+        self.md["static_matmuls"] = static_matmuls
+
+        with open(self.metadata_file, "w") as fp:
+            json.dump(self.md, fp, indent=4)
+
+        return(model, False)
+
+def custom_step_shell_metadata_handover(model, cfg):
+    """ Extracts the metadata for the shell integration process, such as for the v80.
+    This information is stored in a json file that is passed to the build process
+
+    It adds this to the stitched_ip output directory and checks it exists ahead of time
+    """
+    if DataflowOutputType.STITCHED_IP in cfg.generate_outputs:
+        if os.path.isdir(cfg.output_dir + '/stitched_ip'):
+            model = model.transform(ExtractShellIntegrationMetadata(cfg.output_dir + "/stitched_ip/shell_handover.json"))
+            return model
+        else:
+            raise RuntimeError(f"Error: could not find stitched IP directory so unable to create metadata. Please ensure this is called after the create_stitched_ip step")
+
 def custom_step_remove_head(model, cfg):
     """ Removes all nodes up to the first LayerNormalisation Node and then rewires the input """
     assert len(model.graph.input) == 1, "Error the graph has more inputs than expected"
@@ -297,6 +363,8 @@ def custom_step_constrain_folding_and_set_pumped_compute(model, cfg):
     model = model.transform(TempShuffleFixer())
     model = model.transform(SetPumpedCompute())
     return model
+
+
 
 class QuantizeLayerNormalization(Transformation):
     """Add quantization to LayerNormalization nodes in the graph. 


### PR DESCRIPTION
This PR adds a custom step to the TinyBERT build flow that extracts metadata required for the shell integration. It saves this additional information as a json file in the stitched_ip directory. 

This also includes metadata that is required for the MLO use cases.