### PR TITLE
Updates to work with latest finn/custom/transformer branch

### DIFF
--- a/src/finnbrainsmith/custom_op/fpgadataflow/hls/layernorm_hls.py
+++ b/src/finnbrainsmith/custom_op/fpgadataflow/hls/layernorm_hls.py
@@ -44,9 +44,7 @@ class LayerNorm_hls(LayerNorm, BS_HLSBackend):
         super().__init__(onnx_node, **kwargs)
 
     def get_nodeattr_types(self):
-        my_attrs = {
-            "rtlsim_backend": ("s", True, "pyxsi"),
-            }
+        my_attrs = {}
         my_attrs.update(BS_HLSBackend.get_nodeattr_types(self))
         my_attrs.update(LayerNorm.get_nodeattr_types(self))
         return my_attrs

--- a/src/finnbrainsmith/transformation/convert_to_hw_layers.py
+++ b/src/finnbrainsmith/transformation/convert_to_hw_layers.py
@@ -219,7 +219,6 @@ class InferLayerNorm(Transformation):
                     epsilon=helper.get_node_attr_value(node, "epsilon"),
                     inputDataType=idt.name,
                     outputDataType=odt.name,
-                    # rtlsim_backend="pyxsi",
                     name="LayerNorm_" + node.name,
                 )
                 graph.node.insert(insert_point, new_node)


### PR DESCRIPTION
This PR enables BrainSmith to work with the latest changes on finn/custom/transformer [26e54685737c3b69e699b58fd5636a6ff27162f6](https://github.com/Xilinx/finn/commit/26e54685737c3b69e699b58fd5636a6ff27162f6). These changes are primarily related to the deprecation of pyverilator and the removal of the `rtlsim_backend` node attribute.