### PR TITLE
[TinyBERT] Add ref IO to stitched_ip as part of metadata handover

### DIFF
--- a/src/finnbrainsmith/util/bert.py
+++ b/src/finnbrainsmith/util/bert.py
@@ -243,8 +243,8 @@ def custom_step_shell_metadata_handover(model, cfg):
         if os.path.isdir(cfg.output_dir + '/stitched_ip'):
             model = model.transform(ExtractShellIntegrationMetadata(cfg.output_dir + "/stitched_ip/shell_handover.json"))
             # copy over the ref IO *.npy files into the stitched_ip for handover
-            shutil(cfg.verify_input_npy, cfg.output_dir + '/stitched_ip')
-            shutil(cfg.verify_expected_output_npy, cfg.output_dir + '/stitched_ip')
+            shutil.copy(cfg.verify_input_npy, cfg.output_dir + '/stitched_ip')
+            shutil.copy(cfg.verify_expected_output_npy, cfg.output_dir + '/stitched_ip')
             return model
         else:
             raise RuntimeError(f"Error: could not find stitched IP directory so unable to create metadata. Please ensure this is called after the create_stitched_ip step")


### PR DESCRIPTION
Small change that copies the ref IO into the stitched_ip directory as part of the metadata handover process. 