### PR TITLE
Updates to the OpTest class

### DIFF
--- a/tests/fpgadataflow/README.md
+++ b/tests/fpgadataflow/README.md
@@ -52,10 +52,10 @@ check if f_infer_hw_transform == ‘None’ before using this fixture.
 
 <a id="op_test.OpTest.f_model_specialised"></a>
 
-#### f_model_specialised(f_model_hw: ModelWrapper, f_target_fpga: str, f_output_dir: str) → ModelWrapper
+#### f_model_specialised(f_model_hw: ModelWrapper, f_target_fpga: str, f_output_dir: str, f_exec_mode: str, f_target_node: int, f_specialise_attrs: dict[str, any]) → ModelWrapper
 
 A fixture that applies layer specialisation to the ‘f_model_hw’
-fixture, then returns the resulting ModelWrapper.;
+fixture, then returns the resulting ModelWrapper.
 
 * **Parameters:**
   * **f_model_hw** (`qonnx.core.modelwrapper.ModelWrapper`) – Auto-populated by the [`OpTest.f_model_hw()`](#op_test.OpTest.f_model_hw) fixture’s return value
@@ -78,6 +78,21 @@ If this fixture returns ‘None’, OpTest assumes to skip hardware inference.
   (Default: `None`)
 * **Return type:**
   `qonnx.transformation.base.Transformation`
+
+<a id="op_test.OpTest.f_specialise_attrs"></a>
+
+#### f_specialise_attrs() → dict[str, any]
+
+Returns a dictionary containing attributes (i.e. {“SIMD”: 4, “idt”: “INT8”})
+that we’ll attach to the target node (whose index in the graph is found in
+f_target_node) after specialisation (in the f_model_specialised step). Meant to
+be overridden.
+
+* **Returns:**
+  The dictionary of attributes we’ll attach to our target node after specialisation.
+  (Default: `{}`)
+* **Return type:**
+  dict[str, any]
 
 <a id="op_test.OpTest.f_target_fpga"></a>
 
@@ -201,7 +216,7 @@ with the expected number of cycles.
 
 <a id="op_test.OpTest.test_conv_to_hardware"></a>
 
-#### test_conv_to_hardware(f_model, f_model_hw, f_input_tensors)
+#### test_conv_to_hardware(f_model, f_model_hw, f_input_tensors) → None
 
 Compare the outputs of ‘f_model’ and ‘f_model_hw’, when executed using
 ONNX runtime. Ensure that they are functionally identical.
@@ -213,7 +228,7 @@ ONNX runtime. Ensure that they are functionally identical.
 
 <a id="op_test.OpTest.test_specialise_layers"></a>
 
-#### test_specialise_layers(f_model_hw, f_model_specialised, f_input_tensors)
+#### test_specialise_layers(f_model_hw, f_model_specialised, f_input_tensors) → None
 
 Compare the outputs of ‘f_model_hw’ and ‘f_model_specialised’, when executed using
 ONNX runtime. Ensure that they are functionally identical.
@@ -239,8 +254,10 @@ additional boilerplate code.
     model. These tuples have two elements: the first element in each tuple is a dictionary
     containing  any named parameters you’re passing to `onnx.helper.make_tensor_value_info()`.
     The second element is the `QONNX.core.datatype` string that that input will be set to.
-  * **inits** (*List* *(**dict* *)*) – A list of dictionaries, each dictionary representing an initialiser of the model. These should named parameters of ``onnx.numpy_helper.from_array` <[https://onnx.ai/onnx/api/numpy_helper.html#onnx.numpy_helper.to_array](https://onnx.ai/onnx/api/numpy_helper.html#onnx.numpy_helper.to_array)>\`_.
-  * **nodes** (*List* *(**dict* *)*) – A list of dictionaries, each dictionary representing a node of the model. These should named parameters of ``onnx.numpy_helper.from_array` <[https://onnx.ai/onnx/api/helper.html#onnx.helper.make_node](https://onnx.ai/onnx/api/helper.html#onnx.helper.make_node)>\`_.
+  * **inits** (*List* *(**dict* *)*) – A list of dictionaries, each dictionary representing an initialiser of the model. These should named parameters of [onnx.numpy_helper.from_array](https://onnx.ai/onnx/api/numpy_helper.html#onnx.numpy_helper.to_array).
+  * **nodes** (*List* *(**dict* *)*) – 
+
+    A list of dictionaries, each dictionary representing a node of the model. These should named parameters of [onnx.numpy_helper.from_array](https://onnx.ai/onnx/api/helper.html#onnx.helper.make_node).
   * **opset** (*int* *,* *optional*) – The opset of the generated model. Defaults to 17.
     (Default: `17`)
   * **name** (*str* *,* *optional*) – The name of the generated model.
@@ -305,3 +322,14 @@ dictionary, with the name of each parameter as its key.
   A `ModelWrapper` containing the transformed model
 * **Return type:**
   `qonnx.core.modelwrapper.ModelWrapper`
+
+<a id="op_test.OpTest.attach_attributes"></a>
+
+#### attach_attributes(model: ModelWrapper, target_node: int, attributes: dict[str, any]) → None
+
+Attach attributes to a specific node in a model
+
+* **Parameters:**
+  * **model** (`qonnx.core.modelwrapper.ModelWrapper`) – The `ModelWrapper` we’ll apply our node attributes to
+  * **target_node** (*int*) – The index of the node we wish to apply our attributes to.
+  * **attributes** (*dict* *[**str* *,* *any* *]*) – A directory of named attributes, i.e. {“SIMD”: 4, “idt”: “INT8”}

--- a/tests/fpgadataflow/test_fpgadataflow_layernorm.py
+++ b/tests/fpgadataflow/test_fpgadataflow_layernorm.py
@@ -398,7 +398,7 @@ class TestLayerNorm(OpTest):
     def f_idt(self, request):
         return request.param
 
-    @pytest.fixture(params=[(1, 128, 384), (1, 12, 12, 128)])
+    @pytest.fixture(params=[(1, 128, 384), (2, 3)])
     def f_ifm_dim(self, request):
         return request.param
 
@@ -425,7 +425,6 @@ class TestLayerNorm(OpTest):
                     op_type="LayerNormalization",
                     inputs=["X", "Scale", "Bias"],
                     outputs=["Y"],
-                    SIMD=f_simd,
                     preferred_impl_style="hls",
                     ifm_dim=f_ifm_dim,
                     NumChannels=f_ifm_dim[-1],
@@ -443,6 +442,12 @@ class TestLayerNorm(OpTest):
     @pytest.fixture
     def f_infer_hw_transform(self):
         return InferLayerNorm()
+    
+    # Overriding this method allows us to pass attributes
+    # to the model after it's been specialised.
+    @pytest.fixture
+    def f_specialise_attrs(self, f_simd) -> dict[str, any]:
+        return dict(SIMD=f_simd)
 
     # Overriding the default save_intermediate_models fixture
     # (which evaluates to false), so that each model step can


### PR DESCRIPTION
New features & polish for the OpTest class:
- Added intermediate model saving. If the overrideable `f_save_models` fixture evaluates to true, the new `f_auto_saver` fixture (which is added to every test automatically), scrapes all fixtures with names that start with 'f_model' (i.e. `f_model`, `f_model_specialised`) and saves their output to a .onnx file (if the fixtures return a ModelWrapper).
- Added `f_create_output_dir` fixture which automatically checks if a folder for test outputs exists, and creates it if it does not.
- Added a `apply_builder_step()` function applies a FINN builder step to a ModelWrapper. These steps often need specific settings in the form of a DataflowBuildConfig class, so a dummy one is created (based on a dictionary of named parameters).
- The `f_model_specialised` fixture was previously implemented by manually importing and applying transformations which specialise the model. This process was already defined as a FINN Builder step, so the fixture has been reworked to use the FINN Builder step `step_specialize_layers()` (using the 'apply_builder_step' function described above).
- The 'transform_list' parameter for the `apply_transforms` helper function can now (optionally) take a nested (2D) list of transforms. Regular transform-lists are validated after every transform. Nested (2D) transform-lists are validated after every sub-list, so transforms [[1,2,3],[4,5]] would be validated between 3-4, and after 5.
- The global constant string OUTPUT_DIR, used to specify where OpTest will save the output of tests, has been converted into a fixture, so that it is overrideable by tests that inherit from it.
- The `f_model_hw` fixture converts all ONNX layers of a specific type to hardware layers, using a given inference Transformation. If that Transformation does not exist (i.e. infer_hw_transform == 'None'), then the model is directly passed through. All fixtures reliant on hardware inference should check if infer_hw_transform == 'None' before using this fixture.
- The `f_infer_hw_transform` fixture returns a Transformation class that will analyse an ONNX model for layers of a given type, then convert them to their hardware counterparts. By default this fixture returns 'None'.
- Parametrisation moved to fixtures, so tests can pick and choose which parameters they want to see.
- New tests: `test_conv_to_hardware` and `test_specialise_layers`. These tests compare the ONNX runtime outputs of the `f_model_hw` and `f_model_specialised` fixtures with the model fixtures that precede them. This is checked within a tolerance of 1e-5.
- A README.md found in the tests/fpgadataflow directory now documents the fixtures, tests, and helper functions of OpTest.
- General polish (typing, comments, removal of unused imports, etc.)