### PR TITLE
Fix Dynamic Matmul Initial Config For BERT-Large

### DIFF
--- a/demos/bert/gen_initial_folding.py
+++ b/demos/bert/gen_initial_folding.py
@@ -101,7 +101,12 @@ def main(args):
 
         # DynMVUs
         for m in range(0, 2):
-            d = dynmvu(args.pe, int(args.simd / 3))
+            if args.simd % 3 == 0:
+                d = dynmvu(args.pe, int(args.simd/3))
+            elif args.simd % 4 == 0:
+                d = dynmvu(args.pe, int(args.simd/4))
+            else:
+                d = dynmvu(args.pe, args.simd)
             c[f"DynMVU_rtl_{m + (2 * n)}"] = d
 
         # EltwiseAdds


### PR DESCRIPTION
This PR fixes gen_initial_config for instances when the hidden size is not divisable by 3. This was done in preparation for adding BERT-Large.

This also fixes some formatting inconsistencies. We should consider some form of linting in the near future. 