### PR TITLE
Fix BERT demo fifodepth argument

### DIFF
--- a/demos/bert/Makefile
+++ b/demos/bert/Makefile
@@ -2,12 +2,12 @@
 # Copyright (C) 2025, Advanced Micro Devices, Inc.
 # All rights reserved.
 #
-# SPDX-License-Identifier: MIT 
+# SPDX-License-Identifier: MIT
 #
 # @author       Shane T. Fleming <shane.fleming@amd.com>
 ############################################################################
 
-# Warning these premade recipies can be quite fragile. If there are changes in the compiler the configuration can become stale and 
+# Warning these premade recipies can be quite fragile. If there are changes in the compiler the configuration can become stale and
 # incorrect meaning that the fifo depth step needs to be rerun to regenerate the configuration.
 
 folding_three_layers: l3_simd24_pe16
@@ -15,18 +15,18 @@ max_folding_three_layers: l3_simd48_pe32
 small_folding_three_layers: l3_simd12_pe8
 single_layer: l1_simd12_pe8
 
-l3_simd24_pe16: 
+l3_simd24_pe16:
 	python gen_initial_folding.py --simd 24 --pe 16 --num_layers 3 -t 4 -o ./configs/l3_simd24_pe16.json
-	python end2end_bert.py -o l3_simd24_pe16 -n 12 -l 3 -z 384 -i 1536 -x True -p ./configs/l3_simd24_pe16.json
+	python end2end_bert.py -o l3_simd24_pe16 -n 12 -l 3 -z 384 -i 1536 --run_fifo_sizing -p ./configs/l3_simd24_pe16.json
 
-l3_simd48_pe32: 
+l3_simd48_pe32:
 	python gen_initial_folding.py --simd 48 --pe 32 --num_layers 3 -t 4 -o ./configs/l3_simd48_pe32.json
-	python end2end_bert.py -o l3_simd48_pe32 -n 12 -l 3 -z 384 -i 1536 -x True -p ./configs/l3_simd48_pe32.json
+	python end2end_bert.py -o l3_simd48_pe32 -n 12 -l 3 -z 384 -i 1536 --run_fifo_sizing -p ./configs/l3_simd48_pe32.json
 
-l3_simd12_pe8: 
+l3_simd12_pe8:
 	python gen_initial_folding.py --simd 12 --pe 8 --num_layers 3 -t 4 -o ./configs/l3_simd12_pe8.json
-	python end2end_bert.py -o l3_simd12_pe8 -n 12 -l 3 -z 384 -i 1536 -x True -p ./configs/l3_simd12_pe8.json
+	python end2end_bert.py -o l3_simd12_pe8 -n 12 -l 3 -z 384 -i 1536 --run_fifo_sizing -p ./configs/l3_simd12_pe8.json
 
-l1_simd12_pe8: 
+l1_simd12_pe8:
 	python gen_initial_folding.py --simd 12 --pe 8 --num_layers 1 -t 1 -o ./configs/l1_simd12_pe8.json
-	python end2end_bert.py -o l1_simd12_pe8 -n 12 -l 1 -z 384 -i 1536 -x True -p ./configs/l1_simd12_pe8.json
+	python end2end_bert.py -o l1_simd12_pe8 -n 12 -l 1 -z 384 -i 1536 --run_fifo_sizing -p ./configs/l1_simd12_pe8.json

--- a/demos/bert/end2end_bert.py
+++ b/demos/bert/end2end_bert.py
@@ -9,7 +9,7 @@
 
 import warnings
 warnings.simplefilter("ignore")
-import onnx  
+import onnx
 import os
 import argparse
 import torch
@@ -155,7 +155,7 @@ def main(args):
     # Extra metadata for handover
     build_dir = os.path.join(os.environ.get("BSMITH_BUILD_DIR"), args.output)
     handover_file = build_dir + '/stitched_ip/shell_handover.json'
-    
+
     if os.path.exists(handover_file):
         with open(handover_file, "r") as fp:
             handover = json.load(fp)
@@ -175,7 +175,7 @@ if __name__ == "__main__":
     parser.add_argument('-c', '--clk', type=float, default=3.33, help='The target clock rate for the hardware')
     parser.add_argument('-s', '--stop_step', type=str, default=None, help='Step to stop at in the build flow')
     parser.add_argument('-p', '--param', type=str, default=None, help='Use a preconfigured file for the folding parameters')
-    parser.add_argument('-x', '--fifodepth', type=bool, default=True, help='Skip the FIFO depth stage')
+    parser.add_argument('-x', '--run_fifo_sizing', action='store_true', help='Run the fifo-sizing step')
     parser.add_argument('-q', '--seqlen', type=int, default=128, help='Sets the sequence length parameter')
     parser.add_argument('-d', '--dcp', type=bool, default=True, help='Generate a DCP')
     args = parser.parse_args()

--- a/demos/bert/quicktest.sh
+++ b/demos/bert/quicktest.sh
@@ -1,2 +1,2 @@
 python gen_initial_folding.py --simd 12 --pe 8 --num_layers 1 -t 1 -o ./configs/l1_simd12_pe8.json
-python end2end_bert.py -o quicktest -n 12 -l 1 -z 384 -i 1536 -x True -p ./configs/l1_simd12_pe8.json -d False
+python end2end_bert.py -o quicktest -n 12 -l 1 -z 384 -i 1536 --run-fifo-sizing -p ./configs/l1_simd12_pe8.json -d False


### PR DESCRIPTION
The -x,--fifodepth argument cannot be false even when changing the value to -x False actually results in a true value. I change the argument to -x,--run_fifo_sizing to make it more clear and made it a flag with action store_true. Seems to work for both true and false now. 