### PR TITLE
Update BrainSmith to Pytorch 2.7

### DIFF
--- a/docker/requirements.finn.txt
+++ b/docker/requirements.finn.txt
@@ -1,7 +1,7 @@
 # install PyTorch
-torch==2.6.0
-torchvision==0.21.0
-torchaudio==2.6.0 --extra-index-url https://download.pytorch.org/whl/cu121
+torch==2.7.0
+torchvision==0.22.0
+torchaudio==2.7.0 --extra-index-url https://download.pytorch.org/whl/cu121
 # extra Python package dependencies (for testing and interaction)
 pygments==2.14.0
 ipykernel==6.21.2


### PR DESCRIPTION
This PR updates BrainSmith to Pytorch 2.7. 