### PR TITLE
Fix Issue 67: Quicktest pre-calculated folding is currently broken

### DIFF
--- a/examples/bert/bert_quicktest.yaml
+++ b/examples/bert/bert_quicktest.yaml
@@ -10,7 +10,6 @@ output: "bitfile"                   # estimates | rtl | bitfile
 finn_config:
   # Quicktest-specific optimizations
   target_fps: 1                     # Low FPS for quick test (vs 3000 in demo)
-  # NOTE: Quicktest pre-calculated folding is currently broken
-  # folding_config_file: "${BSMITH_DIR}/examples/bert/configs/quicktest_folding.json"  # Quicktest-specific folding
+  folding_config_file: "${BSMITH_DIR}/examples/bert/configs/quicktest_folding.json"  # Quicktest-specific folding
   fifosim_n_inferences: 2           # Speed up FIFO sizing
   verbose: false

--- a/examples/bert/gen_folding_config.py
+++ b/examples/bert/gen_folding_config.py
@@ -63,10 +63,8 @@ def dynmvu(pe: int, simd: int) -> dict:
         "PE": pe,
         "SIMD": simd,
         "ram_style": "auto",
-        "resType": "auto",
-        "mem_mode": "external",
-        "runtime_writeable_weights": 0
-    }
+        "resType": "auto"
+        }
 
 
 def eltwiseadd(pe: int) -> dict:
@@ -102,10 +100,10 @@ def layernorm(simd: int) -> dict:
 def generate_config(args) -> dict:
     """Generate complete folding configuration for BERT model."""
     config = {}
-    
+
     # Add defaults section (empty in original)
     config["Defaults"] = {}
-    
+
     # Generate configuration for each layer
     for n in range(args.num_layers):
         # Generate all MVAUs
@@ -123,42 +121,42 @@ def generate_config(args) -> dict:
             else:
                 d = mvau(args.simd, args.pe, args.runtime_writeable_weights)
             config[f"MVAU_rtl_{m + (8 * n)}"] = d
-        
+
         # DuplicateStreams - 3 per layer
         for m in range(3):
             d = dupstreams(args.other)
             config[f"DuplicateStreams_hls_{m + (3 * n)}"] = d
-        
+
         # Shuffles - 4 per layer
         for m in range(4):
             d = shuffle(args.other)
             config[f"Shuffle_hls_{m + (4 * n)}"] = d
-        
+
         # Thresholding - 9 per layer
         for m in range(9):
             d = thresholding(args.other, 0)
             config[f"Thresholding_rtl_{m + (9 * n)}"] = d
-        
+
         # ElementwiseAdds - 2 per layer
         for m in range(2):
             d = eltwiseadd(args.other)
             config[f"ElementwiseAdd_hls_{m + (2 * n)}"] = d
-        
+
         # ElementwiseMuls - 5 per layer
         for m in range(5):
             d = eltwisemul(args.other)
             config[f"ElementwiseMul_hls_{m + (5 * n)}"] = d
-        
+
         # SoftMax - 1 per layer
         for m in range(1):
             d = softmax(args.other)
             config[f"HWSoftmax_hls_{m + (n * 1)}"] = d
-        
+
         # LayerNorms - 2 per layer
         for m in range(2):
             d = layernorm(args.other)
             config[f"LayerNorm_hls_{m + (n * 2)}"] = d
-    
+
     return config
 
 
@@ -166,46 +164,46 @@ def main():
     parser = argparse.ArgumentParser(
         description='Generate folding configurations for BERT model'
     )
-    
+
     # Output configuration
-    parser.add_argument('-o', '--output', 
+    parser.add_argument('-o', '--output',
                        help='Output JSON config file path',
                        default='config.json')
-    
+
     # MVAU configuration
     parser.add_argument('-s', '--simd', type=int, default=48,
                        help='SIMD setting for MVAU layers')
     parser.add_argument('-p', '--pe', type=int, default=32,
                        help='PE setting for MVAU layers')
-    
+
     # Other operators configuration
     parser.add_argument('-t', '--other', type=int, default=4,
                        help='SIMD/PE for other operators between MVAUs')
-    
+
     # Model configuration
     parser.add_argument('-n', '--num_layers', type=int, default=3,
                        help='Number of BERT hidden layers')
-    
+
     # Runtime configuration
     parser.add_argument('-w', '--runtime_writeable_weights', type=int, default=0,
                        help='Make MVAU weights runtime writeable (0 or 1)')
-    
+
     # Unused in modern version but kept for compatibility
     parser.add_argument('-f', '--shuffleb', type=bool, default=False,
                        help='(Deprecated) ShuffleB parallelization flag')
-    
+
     args = parser.parse_args()
-    
+
     # Generate configuration
     config = generate_config(args)
-    
+
     # Write to file
     output_path = Path(args.output)
     output_path.parent.mkdir(parents=True, exist_ok=True)
-    
+
     with open(output_path, "w") as fp:
         json.dump(config, fp, indent=4)
-    
+
     print(f"Folding configuration generated: {output_path}")
     print(f"  Layers: {args.num_layers}")
     print(f"  MVAU SIMD: {args.simd}, PE: {args.pe}")


### PR DESCRIPTION
The config file generation was applying a memmode configuration to a dynamic Matul which is incorrect since dynamic matmul has no memory. 