### PR TITLE
Fix links to docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,8 +74,9 @@ Found a vulnerability? Report through [Microsoft Security Response Center](https
 ## Help
 
 - Questions: [GitHub Discussions](https://github.com/microsoft/brainsmith/discussions)
-- Bugs: [GitHub Issues](https://github.com/microsoft/Brainsmith/issues)
-- Docs: [microsoft.github.io/brainsmith](https://microsoft.github.io/Brainsmith/)
+
+- Bugs: [GitHub Issues](https://github.com/microsoft/brainsmith/issues)
+- Docs: [microsoft.github.io/brainsmith](https://microsoft.github.io/brainsmith/latest)
 
 ## Code of Conduct
 
@@ -83,4 +84,4 @@ Found a vulnerability? Report through [Microsoft Security Response Center](https
 
 ---
 
-Thanks for contributing!
+Thank you for contributing!

--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ Brainsmith transforms ONNX neural networks into optimized dataflow accelerators 
 - **Schema-Driven Kernels** - Declarative hardware semantics with automatic validation
 - **Component Registry** - Plugin architecture for custom kernels and pipeline steps
 
-**[Documentation](https://microsoft.github.io/Brainsmith/latest)** • **[Discussions](https://github.com/microsoft/brainsmith/discussions)** • **[Roadmap](https://github.com/orgs/microsoft/projects/2017)**
-
+**[Documentation](https://microsoft.github.io/brainsmith/latest)** • **[Discussions](https://github.com/microsoft/brainsmith/discussions)** • **[Roadmap](https://github.com/orgs/microsoft/projects/2017)**
 
 ## Quick Start
 
@@ -45,7 +44,7 @@ source .venv/bin/activate && source .brainsmith/env.sh
 brainsmith project info
 ```
 
-[Detailed installation options and alternative Docker setup →](https://microsoft.github.io/Brainsmith/latest/getting-started/)
+[Detailed installation options and alternative Docker setup →](https://microsoft.github.io/brainsmith/latest/getting-started/)
 
 ### Run Your First Build
 
@@ -57,7 +56,7 @@ cd examples/bert
 ./quicktest.sh
 ```
 
-This generates a single-layer BERT accelerator with RTL simulation. [See example walkthrough →](https://microsoft.github.io/Brainsmith/latest/getting-started/#run-your-first-dse)
+This generates a single-layer BERT accelerator with RTL simulation. [See example walkthrough →](https://microsoft.github.io/brainsmith/latest/getting-started/#run-your-first-dse)
 
 ### Create Custom Accelerators
 
@@ -92,8 +91,7 @@ design_space:
     - "dataflow_partition"
 ```
 
-[Blueprint schema reference →](https://microsoft.github.io/Brainsmith/latest/developer-guide/blueprint-schema/)
-
+[Blueprint schema reference →](https://microsoft.github.io/brainsmith/latest/developer-guide/blueprint-schema/)
 
 ## CLI Overview
 
@@ -111,7 +109,7 @@ brainsmith setup cppsim                 # Setup C++ simulation
 brainsmith project info                 # Show configuration
 ```
 
-[Complete CLI reference →](https://microsoft.github.io/Brainsmith/latest/api/cli/)
+[Complete CLI reference →](https://microsoft.github.io/brainsmith/latest/api/cli/)
 
 ## Contributing
 


### PR DESCRIPTION
Change repo name to lowercase "brainsmith" to algin with Microsoft's conventions, aligned links for GitHub pages docs site